### PR TITLE
v0.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,12 +30,14 @@ jobs:
     name: Build PowerApps-Language-Tooling
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        #os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_NOLOGO: true
       PASOPA_BIN: ./PowerApps-Language-Tooling/bin/Debug/PASopa
       PASOPA_SRC: ./PowerApps-Language-Tooling
+      TOOLS_BIN:  ./Tools
     steps:
       - name: Check out PowerApps-Language-Tooling
         uses: actions/checkout@master
@@ -71,6 +73,34 @@ jobs:
           path: ${{ env.PASOPA_BIN }}
           retention-days: 1
 
+      - name: Install Tools
+        shell: pwsh
+        run: |
+          $toolsDir = "${{ env.TOOLS_BIN }}"
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+          $targetNugetExe = ".\nuget.exe"
+          Remove-Item $toolsDir -Force -Recurse -ErrorAction Ignore
+          Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
+          Set-Alias nuget ".\nuget.exe" -Scope Global -Verbose
+          ##
+          ##Download CoreTools
+          ##
+          . nuget install  Microsoft.CrmSdk.CoreTools -O $toolsDir
+          New-Item $toolsDir\CoreTools -ItemType Directory -Force
+          $coreToolsFolder = Get-ChildItem $toolsDir | Where-Object {$_.Name -match 'Microsoft.CrmSdk.CoreTools.'}
+          Move-Item "$($coreToolsFolder.FullName)\content\bin\coretools\*" -Destination "$toolsDir\CoreTools" -Force
+          Remove-Item $coreToolsFolder.FullName -Force -Recurse       
+        if: ${{ runner.os == 'Windows' }} 
+
+      - name: Tools Bin
+        uses: actions/upload-artifact@v2
+        with:
+          name: Tools-bin-${{ matrix.os }}
+          path: ${{ env.TOOLS_BIN }}
+          retention-days: 1
+        if: ${{ runner.os == 'Windows' }} 
+
   test:
     name: Test
     needs: build-pasopa
@@ -104,6 +134,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: PASopa-bin-windows-latest
+          path: ./bin/windows
+
+      - name: Download Tools-bin-windows-latest
+        uses: actions/download-artifact@v2
+        with:
+          name: Tools-bin-windows-latest
           path: ./bin/windows
 
       - uses: actions/setup-dotnet@v1
@@ -147,6 +183,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: PASopa-bin-windows-latest
+          path: ./bin/windows
+
+      - name: Download Tools-bin-windows-latest
+        uses: actions/download-artifact@v2
+        with:
+          name: Tools-bin-windows-latest
           path: ./bin/windows
 
       - name: Execute the VSCE commands

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,11 +10,13 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_NOLOGO: true
       PASOPA_BIN: ./PowerApps-Language-Tooling/bin/Debug/PASopa
       PASOPA_SRC: ./PowerApps-Language-Tooling
+      TOOLS_BIN:  ./Tools
     steps:
       - name: Check out PowerApps-Language-Tooling
         uses: actions/checkout@master
@@ -50,6 +52,34 @@ jobs:
           path: ${{ env.PASOPA_BIN }}
           retention-days: 1
 
+      - name: Install Tools
+        shell: pwsh
+        run: |
+          $toolsDir = "${{ env.TOOLS_BIN }}"
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+          $targetNugetExe = ".\nuget.exe"
+          Remove-Item $toolsDir -Force -Recurse -ErrorAction Ignore
+          Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
+          Set-Alias nuget ".\nuget.exe" -Scope Global -Verbose
+          ##
+          ##Download CoreTools
+          ##
+          . nuget install  Microsoft.CrmSdk.CoreTools -O $toolsDir
+          New-Item $toolsDir\CoreTools -ItemType Directory -Force
+          $coreToolsFolder = Get-ChildItem $toolsDir | Where-Object {$_.Name -match 'Microsoft.CrmSdk.CoreTools.'}
+          Move-Item "$($coreToolsFolder.FullName)\content\bin\coretools\*" -Destination "$toolsDir\CoreTools" -Force
+          Remove-Item $coreToolsFolder.FullName -Force -Recurse       
+        if: ${{ runner.os == 'Windows' }} 
+
+      - name: Tools Bin
+        uses: actions/upload-artifact@v2
+        with:
+          name: Tools-bin-${{ matrix.os }}
+          path: ${{ env.TOOLS_BIN }}
+          retention-days: 1
+        if: ${{ runner.os == 'Windows' }} 
+
   test:
     name: Test
     needs: build-pasopa
@@ -83,6 +113,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: PASopa-bin-windows-latest
+          path: ./bin/windows
+
+      - name: Download Tools-bin-windows-latest
+        uses: actions/download-artifact@v2
+        with:
+          name: Tools-bin-windows-latest
           path: ./bin/windows
 
       - uses: actions/setup-dotnet@v1
@@ -124,6 +160,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: PASopa-bin-windows-latest
+          path: ./bin/windows
+
+      - name: Download Tools-bin-windows-latest
+        uses: actions/download-artifact@v2
+        with:
+          name: Tools-bin-windows-latest
           path: ./bin/windows
 
       - name: Install dependencies

--- a/0
+++ b/0
@@ -1,0 +1,2 @@
+Missing required argument '/action'.
+Missing required argument '/zipfile'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the "mme2k-powerapps-helper" extension will be documented in this file.
 
+## 0.5.0
+
+* Fixed: Error on Pack Workspace Solution, when no CanvasApps folder was present.
+* Extension supports now multiple solutions in Source Folder. The folder name depends on setting `mme2k-powerapps-helper.SolutionFolderName`.
+* Prepared support for [Microsoft CoE ALM Starter-Kit Solutions](https://github.com/microsoft/coe-starter-kit) (Repository structure, Solution Packer, Multi-Solution-Repo, ...)
+* Crm Solution Packer from [Microsoft.CrmSdk.CoreTools](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools) is now included (only Windows supported)
+* New setting `mme2k-powerapps-helper.CoreToolsSolutionPackager` added. This setting specify the path to the [Microsoft CrmSdk CoreTools Solution-Packer](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools) binary (`SolutionPacker.exe`) tool to pack and unpack solutions.
+* New setting `mme2k-powerapps-helper.UseCrmSolutionPacker` added (default: `true`). This setting allow to use the CrmSdk CoreTools Solution-Packer tool for solution packing and unpacking instead of Zip. ***Note:*** *This might result in a different solution folder structure.*
+* New setting `mme2k-powerapps-helper.SolutionFolderName` added, to define the root folder structure for solutions. These vars can be used: `<SourceFolder>`, `<SolutionName>`. The default is `<SourceFolder>/<SolutionName>`
+* New command `Check Solution Packer Utility` added, to check the availability of the [Microsoft CrmSdk CoreTools Solution-Packer](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools).
+* Output window `Power Apps Helper` added to log output of used command line tools.
+* Fixed: All OAuth connectors were presented for solution import for update `OAuth Settings`. This happened also when the solution did not contains one of them.
+
 ## 0.4.0
 
 * Improved tooltips for tree nodes.

--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ A documentation can be found at:
 
 This extension contributes the following settings:
 
-* `mme2k-powerapps-helper.SourceFileUtility`: Path to the [PowerApps-Language-Tooling](https://github.com/microsoft/PowerApps-Language-Tooling) binary (`PASopa.exe`)
+* `mme2k-powerapps-helper.SourceFileUtility`: Path to the [PowerApps-Language-Tooling](https://github.com/microsoft/PowerApps-Language-Tooling) binary (`PASopa.exe`) to tool to pack and unpack PowerApps.
+* `mme2k-powerapps-helper.CoreToolsSolutionPackager`: Path to the [Microsoft CrmSdk CoreTools Solution-Packer](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools) binary (`SolutionPacker.exe`) tool to pack and unpack solutions.
 * `mme2k-powerapps-helper.SourceFolder`: Source Code Folder to extract the PowerApp
 * `mme2k-powerapps-helper.OutputFolder`: Output Folder for the packed PowerApp
 * `mme2k-powerapps-helper.MaxVisibleVersions`: Count of shown PowerApp versions
 * `mme2k-powerapps-helper.CacheAPIConnectionSecrets`: Cache secrets for API Connections (OAuth Settings, ...)
 * `mme2k-powerapps-helper.APIConnectionSettings`: API Connection Settings (OAuth Settings, ...)
+* `mme2k-powerapps-helper.UseCrmSolutionPacker`: Use the CrmSdk CoreTools Solution-Packer tool for solution packing and unpacking
+* `mme2k-powerapps-helper.SolutionFolderName`: Define the root folder structure for solutions. These vars can be used: `<SourceFolder>`, `<SolutionName>`
 
 ![Settings](./doc/powerapps-settings.png?raw=true)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "name": "mme2k-powerapps-helper",
   "displayName": "PowerApps Helper",
   "description": "PowerApps Helper",
@@ -43,7 +43,8 @@
     "onCommand:mme2k-powerapps-helper.powerapp-api.update-oauth",
     "onCommand:mme2k-powerapps-helper.publish.customizations",
     "onCommand:mme2k-powerapps-helper.clearCredentialCache",
-    "onCommand:mme2k-powerapps-helper.checkSourceFileUtility"
+    "onCommand:mme2k-powerapps-helper.checkSourceFileUtility",
+    "onCommand:mme2k-powerapps-helper.checkSolutionPackerTool"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -54,6 +55,11 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Power Apps Source File Pack and Unpack Utility.\n\n*Download: [PowerApps-Language-Tooling](https://github.com/microsoft/PowerApps-Language-Tooling)*"
+        },
+        "mme2k-powerapps-helper.CoreToolsSolutionPackager": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Microsoft CrmSdk CoreTools Solution-Packer tool to pack and unpack solutions.\n\n*Download: [Microsoft.CrmSdk.CoreTools](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools)*"
         },
         "mme2k-powerapps-helper.SourceFolder": {
           "type": "string",
@@ -79,6 +85,16 @@
           "type": "object",
           "default": { },
           "description": "API Connection Settings (OAuth Settings, ...)"
+        },
+        "mme2k-powerapps-helper.UseCrmSolutionPacker": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Use the CrmSdk CoreTools Solution-Packer tool for solution packing and unpacking"
+        },
+        "mme2k-powerapps-helper.SolutionFolderName": {
+          "type": "string",
+          "default": "<SourceFolder>/<SolutionName>",
+          "description": "Define the root folder structure for solutions. These vars can be used: `<SourceFolder>`, `<SolutionName>`"
         }
       }
     },
@@ -166,6 +182,11 @@
       {
         "command": "mme2k-powerapps-helper.checkSourceFileUtility",
         "title": "Check Source File Utility",
+        "category": "Power Apps"
+      },
+      {
+        "command": "mme2k-powerapps-helper.checkSolutionPackerTool",
+        "title": "Check Solution Packer Utility",
         "category": "Power Apps"
       }
     ],
@@ -270,6 +291,10 @@
         },
         {
           "command": "mme2k-powerapps-helper.checkSourceFileUtility",
+          "when": "true"
+        },
+        {
+          "command": "mme2k-powerapps-helper.checkSolutionPackerTool",
           "when": "true"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { OAuthUtils } from './helpers/OAuthUtils';
 
 let mme2kPowerAppsProvider: PowerAppsDataProvider;
 let mme2kPowerAppsTreeView: vscode.TreeView<TreeItemWithParent>;
+let mme2kPowerAppsOutputChannel: vscode.OutputChannel;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -25,6 +26,9 @@ export function activate(extensionContext: vscode.ExtensionContext) {
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "mme2k-powerapps-helper" is now active!');
+	mme2kPowerAppsOutputChannel = vscode.window.createOutputChannel('Power Apps Helper');
+	mme2kPowerAppsOutputChannel.show(true);
+	mme2kPowerAppsOutputChannel.appendLine(`Power Apps Helper started`);
 
 	mme2kPowerAppsProvider = new PowerAppsDataProvider(vscode.workspace.rootPath);
 	mme2kPowerAppsTreeView = vscode.window.createTreeView('mme2kPowerApps', {
@@ -49,7 +53,19 @@ export function activate(extensionContext: vscode.ExtensionContext) {
 
 	vscode.commands.registerCommand('mme2k-powerapps-helper.clearCredentialCache',       async () => { await Utils.clearCredentialCache(); });
 	
-	vscode.commands.registerCommand('mme2k-powerapps-helper.checkSourceFileUtility',     async () => { if(await Utils.checkSourceFileUtility()) {vscode.window.showInformationMessage(`The Power Apps Source File Pack and Unpack Utility was found.`);}; });
+	vscode.commands.registerCommand('mme2k-powerapps-helper.checkSourceFileUtility',     async () => { if(await Utils.checkPASopaTool()) {vscode.window.showInformationMessage(`The Power Apps Source File Pack and Unpack Utility was found.`);}; });
+	vscode.commands.registerCommand('mme2k-powerapps-helper.checkSolutionPackerTool',    async () => { if(await Utils.checkSolutionPackerTool()) {vscode.window.showInformationMessage(`The CrmSDK CoreTools Solution Tacker Utility was found.`);}; });
+}
+
+export function getOutputChannel(): vscode.OutputChannel {
+	return mme2kPowerAppsOutputChannel;
+}
+
+export function outputHttpLog(text?: string) {
+	getOutputChannel().append((text ?? "") + " ... ");
+}
+export function outputHttpResult(response: any) {
+	getOutputChannel().append(response ? `HTTP/1.1 ${response?.status} ${response?.statusText}\n` : "No Response\n");
 }
 
 export function getTreeViewProvider(): PowerAppsDataProvider {

--- a/src/helpers/Settings.ts
+++ b/src/helpers/Settings.ts
@@ -2,12 +2,21 @@ import * as vscode from 'vscode';
 
 export class Settings {
     
-    private static sourceFileUtilityDefault: string = 'PASopa.exe';
+    private static sourceFileUtilityDefault:         string = 'PASopa.exe';
+    private static coreToolsSolutionPackagerDefault: string = 'SolutionPackager.exe';
 
     static sourceFileUtility(): string {
         let def: string | undefined = vscode.workspace.getConfiguration('mme2k-powerapps-helper').get('SourceFileUtility');
         if (def === undefined || def === '') {
             def = this.sourceFileUtilityDefault;
+        }
+        return `${def}`;
+    }
+
+    static coreToolsSolutionPackager(): string {
+        let def: string | undefined = vscode.workspace.getConfiguration('mme2k-powerapps-helper').get('CoreToolsSolutionPackager');
+        if (def === undefined || def === '') {
+            def = this.coreToolsSolutionPackagerDefault;
         }
         return `${def}`;
     }
@@ -34,6 +43,14 @@ export class Settings {
 
     static cacheAPIConnectionSecretes(): boolean {
         return vscode.workspace.getConfiguration('mme2k-powerapps-helper').get('CacheAPIConnectionSecrets') ?? true;
+    }
+
+    static solutionFolderName(): string {
+        return vscode.workspace.getConfiguration('mme2k-powerapps-helper').get('SolutionFolderName') ?? "";
+    }
+
+    static useCrmSolutionPacker(): boolean {
+        return vscode.workspace.getConfiguration('mme2k-powerapps-helper').get('UseCrmSolutionPacker') ?? true;
     }
 
     static getAPIConnectionSettings(environmentName: string, authentication: string, apiId: string): any {

--- a/src/helpers/SolutionUtils.ts
+++ b/src/helpers/SolutionUtils.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import * as uuid from 'uuid';
+import * as util from 'util';
+import * as stream from 'stream';
 import * as xml2js from 'xml2js';
 import { Settings } from "./Settings";
 import { promises as fsPromises } from 'fs'; 
@@ -9,9 +11,63 @@ import { CanvasApp } from '../entities/CanvasApp';
 import { CloudFlow } from '../entities/CloudFlow';
 import { Connector } from '../entities/Connector';
 import { APIUtils } from './APIUtils';
+import { settings } from 'cluster';
 
 
 export class SolutionUtils {
+
+    static readonly zipSolutionFileLocation = "solution.xml";
+    
+    static readonly crmSolutionFileLocation = `other/${SolutionUtils.zipSolutionFileLocation}`;
+
+
+    /**
+     * pack the Solution
+     * @param sourceFolder path of unpacked Solution sources
+     * @param solutionZip path of the Solution.zip
+     * @returns the buffer of the zip
+     */
+    static async packSolution(sourceFolder: string, solutionZip: string, onSuccess?: Action<any> | undefined, onError?: Action<any> | undefined): Promise<ArrayBuffer | SharedArrayBuffer | undefined> {        
+        
+        if(Settings.useCrmSolutionPacker()) {
+            if (! await Utils.checkSolutionPackerTool()) { return; }
+            const cmd  = await Utils.getSolutionPackerCommandLine(`/action:Pack /folder:"${sourceFolder}" /zipfile:"${solutionZip}" /nologo`);
+            await Utils.executeChildProcess(cmd, (result) => vscode.window.showInformationMessage(`Solution extracted to: ${sourceFolder}`), onError);
+            const fs = require('fs');
+            return fs.readFileSync(`${solutionZip}`);
+        } else {     
+            var zipper = require('zip-local');
+            var zipped = zipper.sync.zip(`${sourceFolder}`).compress();
+            zipped.save(`${solutionZip}`);
+            return zipped.memory();
+        }
+
+    }
+
+    /**
+     * pack the Solution
+     * @param sourceFolder path of unpacked Solution sources     
+     * @param solutionZip path of the Solution.zip 
+     * @returns success
+     */
+    static async unpackSolution(solutionFolder: string, solutionZip: string, onSuccess?: Action<any> | undefined, onError?: Action<any> | undefined): Promise<void> {
+        
+        if(Settings.useCrmSolutionPacker()) {
+            if (! await Utils.checkSolutionPackerTool()) { return; }
+            const cmd  = await Utils.getSolutionPackerCommandLine(`/action:Extract /folder:"${solutionFolder}" /zipfile:"${solutionZip}" /nologo`);
+            await Utils.executeChildProcess(cmd, (message) => vscode.window.showInformationMessage(`Solution packed to: ${solutionZip}`), onError);            
+        } else {
+            const fs = require('fs');
+            const unzip = require('unzipper');
+            var zip = fs.createReadStream(solutionZip);                
+            const finished = util.promisify(stream.finished);
+            await zip.pipe(unzip.Extract({ path: `${solutionFolder}`, concurrency: 5 }));
+            //var result = await new Promise((resolve, reject) => {zip.on('close', function () {resolve(true);}); zip.on('error', () => { reject(false); }); } );
+            await finished(zip);
+            await new Promise( resolve => setTimeout(resolve, 2000) ); // UNZIP must be really finished
+        }
+
+    }
 
     /**
      * Unpack the PowerApp
@@ -26,8 +82,8 @@ export class SolutionUtils {
                 fs.mkdirSync(`${sourceFolder}`, { recursive: true });
             }
 
-            if (! await Utils.checkSourceFileUtility()) { return false; }
-            const cmd    = await Utils.getSourceFileUtilityCommandLine(`-unpack "${powerAppFilePath}" "${sourceFolder}"`);
+            if (! await Utils.checkPASopaTool()) { return false; }
+            const cmd    = await Utils.getPASopaUtilityCommandLine(`-unpack "${powerAppFilePath}" "${sourceFolder}"`);
             return await Utils.executeChildProcess(cmd, onSuccess, onError);
         } catch (err: any) {
             vscode.window.showErrorMessage(`${err}`);
@@ -42,8 +98,8 @@ export class SolutionUtils {
      * @returns success
      */
     static async packPowerApp(powerAppFilePath: string, sourceFolder: string, onSuccess?: Action<any> | undefined, onError?: Action<any> | undefined): Promise<boolean> {
-        if (! await Utils.checkSourceFileUtility()) { return false; }
-        const cmd = await Utils.getSourceFileUtilityCommandLine(`-pack "${powerAppFilePath}" "${sourceFolder}"`);
+        if (! await Utils.checkPASopaTool()) { return false; }
+        const cmd = await Utils.getPASopaUtilityCommandLine(`-pack "${powerAppFilePath}" "${sourceFolder}"`);
         return await Utils.executeChildProcess(cmd, onSuccess, onError);            
     }
 
@@ -82,14 +138,19 @@ export class SolutionUtils {
      * Get the Workspace Solution information
      * @returns the local solution or undefined
      */
-    public static async getWorkspaceSolution() : Promise<any | undefined> {
+    public static async getWorkspaceSolution(isCrmSolution?: boolean, solutionPath?: string) : Promise<any | undefined> {
         let rootPath = vscode.workspace.rootPath;
         if (rootPath === undefined) {
             return undefined;
         }
 
+        solutionPath = solutionPath ?? await this.getWorkspaceSolutionPath();
+        const fs           = require('fs');
+        var solutionFile   = isCrmSolution ?? SolutionUtils.isCrmSolution(solutionPath) ? `${solutionPath}/${SolutionUtils.crmSolutionFileLocation}` : `${solutionPath}/${SolutionUtils.zipSolutionFileLocation}`;
+        if (! fs.existsSync(`${solutionFile}`)) { throw new Error(`SOlution file "${solutionFile}" not found.`); }
+        
         var glob = require("glob-promise");
-        var files = await glob.promise(`${rootPath}/${Settings.sourceFolder()}/solution.xml`, {});
+        var files = await glob.promise(solutionFile, {});
         if ((files?.length || 0) <= 0) { return undefined; };
         var xml    = (await (await fsPromises.readFile(files[0]))).toString('utf8');
         try {
@@ -110,7 +171,8 @@ export class SolutionUtils {
                 "solutionPackageVersion": xmlSolution?.ImportExportXml?.$?.SolutionPackageVersion,
                 "rootComponents":         xmlSolution?.ImportExportXml?.SolutionManifest[0]?.RootComponents.map((rootComponent: any): any => {
                     return { "type": rootComponent?.$?.type, "id": rootComponent?.$?.id, "schemaName": rootComponent?.$?.schemaName, "behavior": rootComponent?.$?.behavior};
-                })
+                }),
+                "solutionPath":           solutionPath
             };
         } catch (err: any) {
             vscode.window.showErrorMessage(`${err}`);
@@ -119,15 +181,86 @@ export class SolutionUtils {
     }
 
     /**
+     * Get or Select the Solution Path
+     * @param solutionName is the name of the solution
+     * @returns true, if the solution.xml exist underneath Other/solution.xml
+     */
+     public static async getWorkspaceSolutionPath(solutionName?: string) : Promise<string> {
+
+        const reSolutionName = /<SolutionName>/gi;
+        const reSourceFolder = /<SourceFolder>/gi;        
+        const solutionPath   = `${Settings.solutionFolderName()}`.replace(reSourceFolder, Settings.sourceFolder());
+        const defaultDir     = `${vscode.workspace.rootPath}/${Settings.sourceFolder()}`;
+        if (! solutionName) {            
+            var solutions = [];
+            for await (const solution of await SolutionUtils.getWorkspaceSolutions() )
+            {
+                solutions.push({
+                    label:        `${solution.displayName}`,
+                    isDefault:    false,
+                    description:  solution.description,
+                    detail:       solution.solutionPath,
+                    solutionName: `${solution.name}`,
+                    solution: solution });
+            }
+            
+            let item = await vscode.window.showQuickPick(solutions);
+            if (item) {
+                return item.solution.solutionPath;
+            }
+            
+            throw Error(`No solution found in: ${defaultDir}`);            
+        }
+        return `${vscode.workspace.rootPath}/${solutionPath.replace(reSolutionName, solutionName)}/`;
+     }
+
+    /**
+     * Get all workspace solutions
+     * @returns all workspace solutions
+     */
+    public static async getWorkspaceSolutions() : Promise<any[]> {
+        const fs         = require('fs');
+        const path       = require('path');
+        const defaultDir = `${vscode.workspace.rootPath}/${Settings.sourceFolder()}`;
+        
+        var solutions : any [] = [];
+        var folders = [`${defaultDir}`];
+        fs.readdirSync(`${defaultDir}`).forEach((name : string) => folders.push(path.resolve(`${defaultDir}/${name}`)));
+        
+        for await (const folder of folders) {
+            if (fs.existsSync(`${folder}/${SolutionUtils.zipSolutionFileLocation}`) 
+             || fs.existsSync(`${folder}/${SolutionUtils.crmSolutionFileLocation}`)) {
+                try {
+                    solutions.push(await SolutionUtils.getWorkspaceSolution(undefined, folder));
+                } catch {}
+            }
+        }
+        return solutions;
+    }
+
+    /**
+     * Check, if the Solution is a CrmSolution
+     * @param solutionPath the path to solution folder
+     * @returns true, if the solution.xml exist underneath Other/solution.xml
+     */
+     public static async isCrmSolution(solutionPath: string) : Promise<boolean> {
+        const fs           = require('fs');
+        return fs.existsSync(`${solutionPath}/${SolutionUtils.crmSolutionFileLocation}`);
+     }
+
+    /**
      * Update the Solution manifest (solution.xml)
      * @param solutionPath the path to solution.xml 
      * @param version ... new solution version
      * @param isManaged ... managed or unmanaged solution     
      */
-    public static async updateSolution(solutionPath: string, version: string, isManaged: boolean) : Promise<void> {
+    public static async updateSolution(solutionPath: string, version: string, isManaged: boolean, isCrmSolution?: boolean) : Promise<void> {
         try {
-            var xmlContent  = (await (await fsPromises.readFile(`${solutionPath}`))).toString('utf8');
-            var xmlSolution = await new Promise<any>((resolve, reject) => {
+            const fs           = require('fs');
+            var solutionFile = isCrmSolution ?? SolutionUtils.isCrmSolution(solutionPath) ? `${solutionPath}/${SolutionUtils.crmSolutionFileLocation}` : `${solutionPath}/${SolutionUtils.zipSolutionFileLocation}`;
+            if (! fs.existsSync(`${solutionFile}`)) { throw new Error(`SOlution file "${solutionFile}" not found.`); }
+            var xmlContent   = (await (await fsPromises.readFile(solutionFile))).toString('utf8');
+            var xmlSolution  = await new Promise<any>((resolve, reject) => {
                 xml2js.parseString(xmlContent, (err: Error, result: any) =>{
                     resolve(result);
                 });
@@ -139,7 +272,7 @@ export class SolutionUtils {
             xmlContent = builder.buildObject(xmlSolution);
 
             // write updated XML string to a file
-            await fsPromises.writeFile(`${solutionPath}`, xmlContent, {encoding: 'utf8'});
+            await fsPromises.writeFile(`${solutionFile}`, xmlContent, {encoding: 'utf8'});
         } catch (err: any) {
             vscode.window.showErrorMessage(`${err}`);
             return;

--- a/src/test/suite/languageTool.test.ts
+++ b/src/test/suite/languageTool.test.ts
@@ -8,7 +8,7 @@ suite('Source File Utility Test', () => {
 
     test('checkSourceFileUtilityFolder', async () => {
         const fs = require('fs');
-        const binPath = await Utils.getSourceFileUtility();
+        const binPath = await Utils.getPASopaPath();
         assert.strictEqual(fs.existsSync(binPath), true, "File was found");
     }).timeout(10000);
 

--- a/src/tree/PowerAppsDataProvider.ts
+++ b/src/tree/PowerAppsDataProvider.ts
@@ -279,16 +279,21 @@ export class PowerAppsDataProvider implements vscode.TreeDataProvider<TreeItemWi
 			return;
 		}
 
-		var localSolution = await SolutionUtils.getWorkspaceSolution();
+		var localSolutions = await SolutionUtils.getWorkspaceSolutions();
 		let items: vscode.QuickPickItem[] = environment.solutions.map(item => {
 			return {
-				description: `${item.uniqueName === localSolution?.uniqueName ? '(workspace)' : ''}`,
+				description: `${localSolutions.find(s => item.uniqueName === s?.uniqueName) ? '(workspace)' : ''}`,
 				detail:      `${item.description || ''}`,
 				label:       `${item.displayName}`,				
 				solution:    item,
-				isDefault:   item.uniqueName === localSolution?.uniqueName
+				isDefault:   localSolutions.find(s => item.uniqueName === s?.uniqueName)
 			};
-		}).sort((app1, app2) => app1.isDefault ? -1 : (app1.label < app2.label ? -1 : 1) );
+		}).sort((s1, s2) => {
+			if (s1.isDefault && ! s2.isDefault) {return -1;}
+			if (! s1.isDefault && s2.isDefault) {return  1;}
+
+			return (s1.label < s2.label ? -1 : 1);
+		});
 		
 		let item = await vscode.window.showQuickPick(items);
 		if (item !== undefined) {


### PR DESCRIPTION
* Fixed: Error on Pack Workspace Solution, when no CanvasApps folder was present.
* Extension supports now multiple solutions in Source Folder. The folder name depends on setting `mme2k-powerapps-helper.SolutionFolderName`.
* Prepared support for [Microsoft CoE ALM Starter-Kit Solutions](https://github.com/microsoft/coe-starter-kit) (Repository structure, Solution Packer, Multi-Solution-Repo, ...)
* Crm Solution Packer from [Microsoft.CrmSdk.CoreTools](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools) is now included (only Windows supported)
* New setting `mme2k-powerapps-helper.CoreToolsSolutionPackager` added. This setting specify the path to the [Microsoft CrmSdk CoreTools Solution-Packer](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools) binary (`SolutionPacker.exe`) tool to pack and unpack solutions.
* New setting `mme2k-powerapps-helper.UseCrmSolutionPacker` added (default: `true`). This setting allow to use the CrmSdk CoreTools Solution-Packer tool for solution packing and unpacking instead of Zip. ***Note:*** *This might result in a different solution folder structure.*
* New setting `mme2k-powerapps-helper.SolutionFolderName` added, to define the root folder structure for solutions. These vars can be used: `<SourceFolder>`, `<SolutionName>`. The default is `<SourceFolder>/<SolutionName>`
* New command `Check Solution Packer Utility` added, to check the availability of the [Microsoft CrmSdk CoreTools Solution-Packer](https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools).
* Output window `Power Apps Helper` added to log output of used command line tools.
* Fixed: All OAuth connectors were presented for solution import for update `OAuth Settings`. This happened also when the solution did not contains one of them.