### PR TITLE
Correct message to "unpacked" rather than "packed"

### DIFF
--- a/src/helpers/SolutionUtils.ts
+++ b/src/helpers/SolutionUtils.ts
@@ -58,7 +58,7 @@ export class SolutionUtils {
         if(Settings.useCrmSolutionPacker()) {
             if (! await Utils.checkSolutionPackerTool()) { return; }
             const cmd  = await Utils.getSolutionPackerCommandLine(`/action:Extract /folder:"${solutionFolder}" /zipfile:"${solutionZip}" /nologo /allowDelete:Yes`);
-            await Utils.executeChildProcess(cmd, (message) => vscode.window.showInformationMessage(`Solution packed to: ${solutionZip}`), onError);            
+            await Utils.executeChildProcess(cmd, (message) => vscode.window.showInformationMessage(`Solution unpacked to: ${solutionZip}`), onError);            
         } else {
             const fs = require('fs');
             const unzip = require('unzipper');


### PR DESCRIPTION
When unpacking a solution, the information message displayed in VS Code incorrectly displays the word "packed" rather than "unpacked".