### PR TITLE
Improve description in Download and Unpack "quick pick" dialog

### DIFF
--- a/src/tree/PowerAppsDataProvider.ts
+++ b/src/tree/PowerAppsDataProvider.ts
@@ -124,7 +124,7 @@ export class PowerAppsDataProvider implements vscode.TreeDataProvider<TreeItemWi
 			let item = await vscode.window.showQuickPick([
 				{label: `All`,      description: `Publish All solution customizations (recommended)`, result: 'all', default: true},
 				{label: `Solution`, description: `Publish solution customizations`,                   result: 'solution'},
-				{label: `No`,       description: `Download solution 'as-is'`,                         result: 'no'}
+				{label: `No`,       description: `Download and unpack solution 'as-is'`,              result: 'no'}
 			]) as any;
 			if (! item?.result) { return; }
 			if (item?.result === 'all') {


### PR DESCRIPTION
We have found some new users to the extension being uncertain which item to choose in the "quick pick" dialog displayed when downloading and unpacking the solution.

This pull request contains a small text change to make it clearer to users what action the No option performs