### PR TITLE
Fix environment comparison case sensitivity and update Microsoft.PowerApps.CLI to 1.8.5

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,8 +9,8 @@ const gulp = require('gulp');
 const eslint = require('gulp-eslint');
 const mocha = require('gulp-mocha');
 const moment = require('moment');
-const gulpWebpack = require('webpack-stream');
-const webpack = require('webpack');
+// const gulpWebpack = require('webpack-stream');
+// const webpack = require('webpack');
 const vsce = require('vsce');
 const argv = require('yargs').argv;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -209,8 +209,8 @@ async function snapshot() {
 
 const recompile = gulp.series(
     clean,
-    async () => nugetInstall('nuget.org', 'Microsoft.PowerApps.CLI', '1.7.2', path.resolve(distdir, 'pac')),
-    async () => nugetInstall('nuget.org', 'Microsoft.PowerApps.CLI.Core.osx-x64', '1.7.2', path.resolve(distdir, 'pac')),
+    async () => nugetInstall('nuget.org', 'Microsoft.PowerApps.CLI', '1.8.5', path.resolve(distdir, 'pac')),
+    async () => nugetInstall('nuget.org', 'Microsoft.PowerApps.CLI.Core.osx-x64', '1.8.5', path.resolve(distdir, 'pac')),
     compile,
 );
 

--- a/src/entities/PowerApp.ts
+++ b/src/entities/PowerApp.ts
@@ -10,7 +10,7 @@ import { env } from 'process';
 import { APIUtils } from '../helpers/APIUtils';
 
 export class PowerApp extends TreeItemWithParent {
-	
+
     constructor(
         public readonly id: string,
         public readonly name: string,
@@ -23,9 +23,9 @@ export class PowerApp extends TreeItemWithParent {
         public readonly environment: Environment | undefined,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         public readonly command?: vscode.Command
-    ) {        
+    ) {
         super(`${displayName}`, collapsibleState);
-        
+
         this.id          = id;
         this.name        = name;
         this.displayName = displayName;
@@ -43,7 +43,7 @@ export class PowerApp extends TreeItemWithParent {
             `|-:|:-:|:-|`,
             `|*Name:*               ||${name}|`,
             `|*App-Version:*        ||${version}|`,
-            `|*App Plan Classification:*||${this.properties?.appPlanClassification}|`,  
+            `|*App Plan Classification:*||${this.properties?.appPlanClassification}|`,
             `|*Designer-Version:*   ||${this.properties?.createdByClientVersion?.major}.${this.properties?.createdByClientVersion?.minor}.${this.properties?.createdByClientVersion?.build}.${this.properties?.createdByClientVersion?.revision}|`,
             `|*CanvasApp-Id:*       ||${id?.split("/")?.slice(-1)[0]}|`,  // unauthenticatedWebPackageHint
             `|*Id:*                 ||${id}|`,
@@ -70,25 +70,25 @@ export class PowerApp extends TreeItemWithParent {
 		light: path.join(path.dirname(__filename), '..', '..', 'media', 'powerapps.svg'),
 		dark: path.join(path.dirname(__filename), '..', '..', 'media', 'powerapps.svg')
 	};
-    
-    public connections?: Connection[];    
-    
+
+    public connections?: Connection[];
+
     static convert (data: any, environments?: Environment[]): PowerApp {
         const properties    = data.properties;
         const version       = properties.appPackageDetails !== undefined ? properties.appPackageDetails.documentServerVersion : {};
         const toConnections = (app: PowerApp, connections: any): Connection[] => { return connections === undefined ? [] : Object.entries(connections).map<Connection>(([k, v]) => Connection.convert(app, k, v)); };
-        const environment   = environments?.filter(e => e.id === properties.environment.id)[0];
+        const environment   = environments?.filter(e => e.id.toLowerCase() === properties.environment.id.toLowerCase())[0];
         const powerApp      = new PowerApp(
             data.id,
-            data.name, 
-            version !== undefined ? `${version.major}.${version.minor}.${version.build}.${version.revision}` : "", 
-            properties.displayName, 
-            properties.description, 
-            properties.appOpenUri, 
+            data.name,
+            version !== undefined ? `${version.major}.${version.minor}.${version.build}.${version.revision}` : "",
+            properties.displayName,
+            properties.description,
+            properties.appOpenUri,
             properties.appUris !== undefined && properties.appUris.documentUri !== undefined ? properties.appUris.documentUri.value : undefined,
             properties,
             environment,
-            vscode.TreeItemCollapsibleState.Collapsed, 
+            vscode.TreeItemCollapsibleState.Collapsed,
             undefined);
 
         powerApp.connections = toConnections(powerApp, properties.connectionReferences);


### PR DESCRIPTION
Hello Michael,

Thank you for your efforts. We have run into a bug where existing published PowerApps are not being displayed under the PowerApps node.

The Get-Apps API call returns the results as expected but are subsequently filtered out due to an environment.id mismatched comparison because of case sensitivity. (Default vs default). This PR fixes the issue by lowercasing the comparison.

Also, webpack requirements in the gulpfile were commented out since they are not used and raise an error.

Lastly, the PowerApps.CLI nuget package was updated to the latest version 1.8.5.
